### PR TITLE
refactor: make help message readable

### DIFF
--- a/functions/src/sukkirisuBot/useCase/showHelpMessage/showHelpMessage.spec.ts
+++ b/functions/src/sukkirisuBot/useCase/showHelpMessage/showHelpMessage.spec.ts
@@ -25,10 +25,10 @@ describe("ShowHelpMessage", () => {
 
   it("should get correct help message", async () => {
     const actual = await useCase.getHelpMessage();
-    const expected = `メンションして以下を含めた投稿を行ってください
-スッキりす：今日のすっきりすランキングを全て表示
-個人スッキりす：ユーザとその誕生月を設定した場合、登録されているユーザのランキングを表示
-{ユーザー}は{誕生月}月生まれ：ユーザに対して誕生月を設定する。ユーザーはローマ字で指定、誕生月は数字で指定
+    const expected = `コマンド一覧。コマンドは日本語です
+Sukkirisu Bot スッキりす （全てのランキングを表示）
+Sukkirisu Bot 個人スッキりす （登録されているユーザのランキングを表示）
+Sukkirisu Bot <ユーザー名>は<誕生月>月生まれ （ユーザーを登録。ex. gansekiは12月生まれ）
 
 0分~30分、31~59分の30分単位で再度リクエストを送ることができるようになります`;
     stubbed.calledOnce.should.be.true;

--- a/functions/src/sukkirisuBot/useCase/showHelpMessage/showHelpMessage.spec.ts
+++ b/functions/src/sukkirisuBot/useCase/showHelpMessage/showHelpMessage.spec.ts
@@ -28,7 +28,7 @@ describe("ShowHelpMessage", () => {
     const expected = `コマンド一覧。コマンドは日本語です
 Sukkirisu Bot スッキりす （全てのランキングを表示）
 Sukkirisu Bot 個人スッキりす （登録されているユーザのランキングを表示）
-Sukkirisu Bot <ユーザー名>は<誕生月>月生まれ （ユーザーを登録。ex. gansekiは12月生まれ）
+Sukkirisu Bot <ユーザー名>は<誕生月>月生まれ （ユーザーを登録。ex. abcは12月生まれ）
 
 0分~30分、31~59分の30分単位で再度リクエストを送ることができるようになります`;
     stubbed.calledOnce.should.be.true;

--- a/functions/src/sukkirisuBot/useCase/showHelpMessage/showHelpMessage.ts
+++ b/functions/src/sukkirisuBot/useCase/showHelpMessage/showHelpMessage.ts
@@ -38,7 +38,7 @@ export class ShowHelpMessage {
     return `コマンド一覧。コマンドは日本語です
 Sukkirisu Bot スッキりす （全てのランキングを表示）
 Sukkirisu Bot 個人スッキりす （登録されているユーザのランキングを表示）
-Sukkirisu Bot <ユーザー名>は<誕生月>月生まれ （ユーザーを登録。ex. gansekiは12月生まれ）
+Sukkirisu Bot <ユーザー名>は<誕生月>月生まれ （ユーザーを登録。ex. abcは12月生まれ）
 
 0分~30分、31~59分の30分単位で再度リクエストを送ることができるようになります`;
   }

--- a/functions/src/sukkirisuBot/useCase/showHelpMessage/showHelpMessage.ts
+++ b/functions/src/sukkirisuBot/useCase/showHelpMessage/showHelpMessage.ts
@@ -35,10 +35,10 @@ export class ShowHelpMessage {
   async getHelpMessage(): Promise<string> {
     await this.ensureCallableOncePerHalfHour();
 
-    return `メンションして以下を含めた投稿を行ってください
-スッキりす：今日のすっきりすランキングを全て表示
-個人スッキりす：ユーザとその誕生月を設定した場合、登録されているユーザのランキングを表示
-{ユーザー}は{誕生月}月生まれ：ユーザに対して誕生月を設定する。ユーザーはローマ字で指定、誕生月は数字で指定
+    return `コマンド一覧。コマンドは日本語です
+Sukkirisu Bot スッキりす （全てのランキングを表示）
+Sukkirisu Bot 個人スッキりす （登録されているユーザのランキングを表示）
+Sukkirisu Bot <ユーザー名>は<誕生月>月生まれ （ユーザーを登録。ex. gansekiは12月生まれ）
 
 0分~30分、31~59分の30分単位で再度リクエストを送ることができるようになります`;
   }


### PR DESCRIPTION
It is difficult to understand help message now.
I improved the message readability.

（before）
![image](https://user-images.githubusercontent.com/36080801/185833630-c9f4ab6c-1b0c-4547-85e0-8fb574493806.png)

(after)

```
コマンド一覧。コマンドは日本語です
\@Sukkirisu Bot スッキりす （全てのランキングを表示）
\@Sukkirisu Bot 個人スッキりす （登録されているユーザのランキングを表示）
\@Sukkirisu Bot <ユーザー名>は<誕生月>月生まれ （ユーザーを登録。ex. gansekiは12月生まれ）
0分~30分、31~59分の30分単位で再度リクエストを送ることができるようになります
```